### PR TITLE
Improvements on display glitching

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -659,6 +659,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "stats"
+version = "0.1.0"
+dependencies = [
+ "cortex-m",
+ "cortex-m-rt",
+ "defmt",
+ "defmt-rtt",
+ "embassy-executor",
+ "embassy-stm32",
+ "libm",
+ "panic-probe",
+]
+
+[[package]]
 name = "stm32-fmc"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -697,6 +711,8 @@ dependencies = [
  "panic-probe",
  "ringbuffer",
  "static_cell",
+ "stats",
+ "time_stats",
 ]
 
 [[package]]
@@ -745,6 +761,21 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.39",
+]
+
+[[package]]
+name = "time_stats"
+version = "0.1.0"
+dependencies = [
+ "cortex-m",
+ "cortex-m-rt",
+ "defmt",
+ "defmt-rtt",
+ "embassy-executor",
+ "embassy-stm32",
+ "embassy-time",
+ "panic-probe",
+ "stats",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -129,7 +129,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.39",
+ "syn 2.0.40",
 ]
 
 [[package]]
@@ -140,7 +140,7 @@ checksum = "836a9bbc7ad63342d6d6e7b815ccab164bc77a2d95d84bc3117a8c0d5c98e2d5"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.40",
 ]
 
 [[package]]
@@ -163,7 +163,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.40",
 ]
 
 [[package]]
@@ -242,7 +242,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.40",
 ]
 
 [[package]]
@@ -441,7 +441,7 @@ checksum = "53b153fd91e4b0147f4aced87be237c98248656bb01050b96bf3ee89220a8ddb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.40",
 ]
 
 [[package]]
@@ -734,9 +734,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.39"
+version = "2.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23e78b90f2fcf45d3e842032ce32e3f2d1545ba6636271dcbf24fa306d87be7a"
+checksum = "13fa70a4ee923979ffb522cacce59d34421ebdea5625e1073c4326ef9d2dd42e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -760,7 +760,7 @@ checksum = "266b2e40bc00e5a6c09c3584011e08b06f123c00362c92b975ba9843aaaa14b8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.40",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,3 +24,6 @@ static_cell = { version = "2", features = ["nightly"]}
 libm = "0.2.8"
 heapless = { version = "0.8", default-features = false }
 ringbuffer = { version = "0.15", default-features = false } # no_std
+
+stats = { path="../stats" }
+time_stats = { path="../time-stats" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,5 +25,5 @@ libm = "0.2.8"
 heapless = { version = "0.8", default-features = false }
 ringbuffer = { version = "0.15", default-features = false } # no_std
 
-stats = { path="../stats" }
-time_stats = { path="../time-stats" }
+stats = { path="stats" }
+time_stats = { path="time_stats" }

--- a/src/c5412.rs
+++ b/src/c5412.rs
@@ -22,6 +22,7 @@ use core::sync::atomic::AtomicU32;
 
 // Async communication with other threads
 static COUNT_ATOMIC: AtomicU32 = AtomicU32::new(0); // Profiling: # of refreshes so far
+static OVERRUN_ATOMIC: AtomicU32 = AtomicU32::new(0); // Profiling: # of overruns
 
 pub struct C5412Pins {
     pub p11: embassy_stm32::gpio::Output<'static, AnyPin>,
@@ -142,8 +143,10 @@ pub async fn process(c5412pins_ref: &'static mut C5412Pins,
     const OFF_TIME_MS : u64 = 5;
     let mut count : u32 = 0; // For profiling the refresh rate. Just counts
     let mut when = Instant::now().as_millis();
+    let mut overrun : u32 = 0;
     loop {
         COUNT_ATOMIC.store(count, Ordering::Relaxed);
+        OVERRUN_ATOMIC.store(overrun, Ordering::Relaxed);
         let x : u32 = value_atomic.load(Ordering::Relaxed); // What to display
 
         // Cathode 1: The 10's digit
@@ -151,18 +154,22 @@ pub async fn process(c5412pins_ref: &'static mut C5412Pins,
         c5412pins_ref.digit_on(((x/10)%10) as u8);
         when += ON_TIME_MS;
         Timer::at(Instant::from_millis(when)).await;
+        if Instant::now().as_millis() > when { overrun += 1; }
         c5412pins_ref.all_off();
         when += OFF_TIME_MS;
         Timer::at(Instant::from_millis(when)).await;
+        if Instant::now().as_millis() > when { overrun += 1; }
 
         // Cathode 2: The 1's digit
         c5412pins_ref.common_2_on();
         c5412pins_ref.digit_on((x%10) as u8);
         when += ON_TIME_MS;
         Timer::at(Instant::from_millis(when)).await;
+        if Instant::now().as_millis() > when { overrun += 1; }
         c5412pins_ref.all_off();
         when += OFF_TIME_MS;
         Timer::at(Instant::from_millis(when)).await;
+        if Instant::now().as_millis() > when { overrun += 1; }
 
         count+=1;
     }
@@ -170,3 +177,5 @@ pub async fn process(c5412pins_ref: &'static mut C5412Pins,
 
 // Thread safe: Get number of display refreshes since boot
 pub fn get_count() -> u32 { COUNT_ATOMIC.load(Ordering::Relaxed) }
+
+pub fn get_overrun() -> u32 { OVERRUN_ATOMIC.load(Ordering::Relaxed) }

--- a/src/hr_alg3.rs
+++ b/src/hr_alg3.rs
@@ -119,8 +119,9 @@ impl Hr {
         if self.above_pts.capacity() > 1 {
             let mut above_max = 0i32;
             let mut above_ix = 0usize;
+            /* This is slow when not --release, and it seems after_ticks is the problem */
             for (i, val) in self.above_pts.iter().enumerate() {
-                Timer::after_ticks(0).await; // yield
+                // Timer::after_ticks(0).await; // yield
                 if above_max < *val {
                     above_max = *val;
                     above_ix = i;

--- a/src/hr_alg3.rs
+++ b/src/hr_alg3.rs
@@ -1,6 +1,5 @@
 // hr_alg3: Heartrate Algorithm #3, including processing task
 
-use embassy_time::Timer;
 use ringbuffer::{ConstGenericRingBuffer, RingBuffer};
 
 const CRAZY_HI: i32 =3000;

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,7 +30,8 @@ use stats::Stats;
 enum HrDebugMode {
     Info,
     Debug,
-    Stats
+    Stats,
+    DisplayOverrun,
 }
 #[derive(PartialEq, Eq)]
 enum DebugMode {
@@ -40,7 +41,7 @@ enum DebugMode {
     DumpTiming,
 }
 
-const DEBUG_MODE : DebugMode = DebugMode::Hr(HrDebugMode::Info);
+const DEBUG_MODE : DebugMode = DebugMode::Hr(HrDebugMode::DisplayOverrun);
 
 //
 // Things needed for 14-segment driver processing task
@@ -165,6 +166,10 @@ async fn process_hr(uart_ref: &'static mut UART,
                         HrDebugMode::Info => {
                             let err = dadc_n as i32 - dproc_n as i32;
                             core::fmt::write(&mut msg, format_args!("{:.2} {:.2} {}\n", rate, refresh, err)).unwrap();
+                        }
+                        HrDebugMode::DisplayOverrun => {
+                            let overrun = c5412::get_overrun();
+                            core::fmt::write(&mut msg, format_args!("{:.2} {:.2} {}\n", rate, refresh, overrun)).unwrap();
                         }
                     }
                     _ = (uart_ref).write(msg.as_bytes()).await;

--- a/src/main.rs
+++ b/src/main.rs
@@ -59,7 +59,7 @@ static LED3_INST: StaticCell<LED3> = StaticCell::new();
 type BUTTON1 = embassy_stm32::gpio::Input<'static, embassy_stm32::peripherals::PC13>;
 static BUTTON1_INST: StaticCell<BUTTON1> = StaticCell::new();
 
-const DUMP_MODE: bool = true;
+const DUMP_MODE: bool = false;
 
 // Heartrate computation task
 // Simply call hr::tick(sample) and output something based on results
@@ -81,7 +81,7 @@ async fn process_hr(uart_ref: &'static mut UART,
         let sample = SAMPLE_SIGNAL.wait().await;
         let lp = button1_ref.get_level() == Level::Low;
         led3_ref.set_level(if !lp { High } else { Low });
-        let (n, cooked_sample, _peak, state, hr_update) = hr.tick(lp, sample);
+        let (n, cooked_sample, _peak, state, hr_update) = hr.tick(lp, sample).await;
         // If we got a heartrate update, reflect it on LED
         if hr_update != 0 {
             display_value_atomic.store(hr.hr() as u32, Ordering::Relaxed);
@@ -99,7 +99,7 @@ async fn process_hr(uart_ref: &'static mut UART,
         // If we got a heartrate update, reflect it on UART console
         if hr_update != 0 {
             let rate = hr.hr();
-            let (a, b) = hr.above_below(); // FIXME: This is a slow operation
+            let (a, b) = hr.above_below().await; // This is a slow operation
             let d = a-b;
             let count = c5412::get_count();
             let refresh = 1000f64 * (count-count0) as f64 / (n-n0) as f64;

--- a/src/main.rs
+++ b/src/main.rs
@@ -142,8 +142,6 @@ async fn process_hr(uart_ref: &'static mut UART,
                 // If we got a heartrate update, reflect it on UART console
                 if hr_update != 0 {
                     let rate = hr.hr();
-                    // let (a, b) = hr.above_below().await; // This is a slow operation // FIXME remove this and retime
-                    // let _range = a-b;
                     let dcount = count-count0;
                     let dproc_n = proc_n-proc_n0;
                     let dadc_n = adc_n-adc_n0;

--- a/stats/.cargo/config.toml
+++ b/stats/.cargo/config.toml
@@ -1,0 +1,12 @@
+[target.thumbv7em-none-eabihf]
+runner = 'probe-rs run --chip STM32H743ZITx'
+
+[build]
+target = "thumbv7em-none-eabihf" # Cortex-M4F and Cortex-M7F (with FPU)
+
+[env]
+DEFMT_LOG = "trace"
+
+[profile.release]
+# Allows defmt to display log locations even in release
+debug = true

--- a/stats/Cargo.toml
+++ b/stats/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "stats"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+# Change stm32h743zi to your chip name, if necessary.
+embassy-stm32 = { version = "0.1.0", path = "../../embassy-stm32", features = ["defmt", "stm32h743zi", "time-driver-any", "exti", "memory-x", "unstable-pac", "chrono"] }
+embassy-executor = { version = "0.3.3", path = "../../embassy-executor", features = ["nightly", "arch-cortex-m", "executor-thread", "defmt", "integrated-timers"] }
+
+defmt = "0.3"
+defmt-rtt = "0.4"
+
+cortex-m = { version = "0.7.6", features = ["inline-asm", "critical-section-single-core"] }
+cortex-m-rt = "0.7.0"
+panic-probe = { version = "0.3", features = ["print-defmt"] }
+libm = "0.2.8"

--- a/stats/build.rs
+++ b/stats/build.rs
@@ -1,0 +1,5 @@
+fn main() {
+    println!("cargo:rustc-link-arg-bins=--nmagic");
+    println!("cargo:rustc-link-arg-bins=-Tlink.x");
+    println!("cargo:rustc-link-arg-bins=-Tdefmt.x");
+}

--- a/stats/src/lib.rs
+++ b/stats/src/lib.rs
@@ -1,0 +1,66 @@
+#![no_std]
+#![no_main]
+#![feature(type_alias_impl_trait)]
+
+use libm::{sqrt,fmin,fmax};
+
+#[derive(Copy, Clone)]
+pub struct Stats {
+    n : f64,
+    sx : f64,
+    sxx : f64,
+    minx : f64,
+    maxx : f64
+}
+
+impl Stats {
+    pub fn new() -> Self { Self { n:0.0, sx:0.0, sxx:0.0, minx:0.0, maxx:0.0}}
+    pub fn reset(&mut self) { self.n=0.0; self.sx=0.0; self.sxx=0.0;
+                              self.minx=0.0; self.maxx=0.0;}
+    pub fn add(&mut self, x:f64) {
+        if self.n == 0.0 {
+            self.minx = x;
+            self.maxx = x;
+        } else {
+            self.minx = fmin(self.minx, x);
+            self.maxx = fmax(self.maxx, x);
+        }
+        self.n += 1.0;
+        self.sx += x;
+        self.sxx += x*x;
+    }
+    pub fn n(&self) -> u32 { self.n as u32 }
+    pub fn min(&self) -> f64 {
+        if self.n > 0.0 { self.minx } else { f64::NAN }
+    }
+    pub fn max(&self) -> f64 {
+        if self.n > 0.0 { self.maxx } else { f64::NAN }
+    }
+    pub fn mean(&self) -> f64 {
+        if self.n > 0.0 { self.sx/self.n } else { f64::NAN }
+    }
+    pub fn std(&self) -> f64 {
+        if self.n > 1.0 {
+            sqrt((self.sxx - self.sx*self.sx/self.n) / (self.n-1.0))
+        } else { f64::NAN }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_works() {
+        let mut s = Stats::new();
+        s.add(3.0);
+        s.add(4.0);
+        s.add(3.0);
+        s.add(4.0);
+        assert_eq!(s.n(), 4u32);
+        assert_eq!(s.min(), 3.0);
+        assert_eq!(s.max(), 4.0);
+        assert_eq!(s.mean(), 3.5);
+        assert_eq!(s.std(), sqrt(1.0/3.0));
+    }
+}

--- a/stats/src/main.rs
+++ b/stats/src/main.rs
@@ -1,0 +1,24 @@
+#![no_std]
+#![no_main]
+#![feature(type_alias_impl_trait)]
+
+use defmt::*;
+use {defmt_rtt as _, panic_probe as _};
+use embassy_executor::Spawner;
+
+use stats::Stats;
+
+#[embassy_executor::main]
+async fn main(_spawner: Spawner) {
+    let _ = embassy_stm32::init(Default::default());
+    let mut s = Stats::new();
+    s.add(3.0);
+    s.add(4.0);
+    s.add(3.0);
+    s.add(4.0);
+    println!("{}", s.n());
+    println!("{}", s.min());
+    println!("{}", s.max());
+    println!("{}", s.mean());
+    println!("{}", s.std()); // Sqrt(1/3)
+}

--- a/time_stats/.cargo/config.toml
+++ b/time_stats/.cargo/config.toml
@@ -1,0 +1,12 @@
+[target.thumbv7em-none-eabihf]
+runner = 'probe-rs run --chip STM32H743ZITx'
+
+[build]
+target = "thumbv7em-none-eabihf" # Cortex-M4F and Cortex-M7F (with FPU)
+
+[env]
+DEFMT_LOG = "trace"
+
+[profile.release]
+# Allows defmt to display log locations even in release
+debug = true

--- a/time_stats/Cargo.toml
+++ b/time_stats/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "time_stats"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+# Change stm32h743zi to your chip name, if necessary.
+embassy-stm32 = { version = "0.1.0", path = "../../embassy-stm32", features = ["defmt", "stm32h743zi", "time-driver-any", "exti", "memory-x", "unstable-pac", "chrono"] }
+embassy-executor = { version = "0.3.3", path = "../../embassy-executor", features = ["nightly", "arch-cortex-m", "executor-thread", "defmt", "integrated-timers"] }
+embassy-time = { version = "0.1.5", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime", "tick-hz-1_000_000"] }
+
+defmt = "0.3"
+defmt-rtt = "0.4"
+
+cortex-m = { version = "0.7.6", features = ["inline-asm", "critical-section-single-core"] }
+cortex-m-rt = "0.7.0"
+panic-probe = { version = "0.3", features = ["print-defmt"] }
+stats = { version="0", path="../stats" }

--- a/time_stats/build.rs
+++ b/time_stats/build.rs
@@ -1,0 +1,5 @@
+fn main() {
+    println!("cargo:rustc-link-arg-bins=--nmagic");
+    println!("cargo:rustc-link-arg-bins=-Tlink.x");
+    println!("cargo:rustc-link-arg-bins=-Tdefmt.x");
+}

--- a/time_stats/src/lib.rs
+++ b/time_stats/src/lib.rs
@@ -1,0 +1,64 @@
+#![no_std]
+#![no_main]
+#![feature(type_alias_impl_trait)]
+
+//use libm::{sqrt,fmin,fmax};
+//use heapless::String;
+use embassy_time::{Instant,Duration};
+use stats::Stats;
+
+pub struct TimeStats {
+    started: bool,
+    start: Instant,
+    stop: Instant,
+    delta: Duration,
+    stats: Stats
+}
+
+impl TimeStats {
+    pub fn new() -> Self {
+        Self {
+            stats: Stats::new(),
+            started: false,
+            start: Instant::from_ticks(0),
+            stop: Instant::from_ticks(0),
+            delta: Duration::from_ticks(0),
+        }
+    }
+    pub fn loop_tick(&mut self) {
+        if self.started {
+            self.stop = Instant::now();
+            self.delta = self.stop - self.start;
+            self.start = self.stop;
+            self.stats.add(self.delta.as_micros() as f64)
+        } else {
+            self.start = Instant::now();
+            self.started = true;
+        }
+    }
+    pub fn start_tick(&mut self) {
+        if self.started {
+            panic!("Can't do this")
+        } else {
+            self.start = Instant::now();
+            self.started = true;
+        }
+    }
+    pub fn stop_tick(&mut self) {
+        if self.started {
+            self.stop = Instant::now();
+            self.delta = self.stop - self.start;
+            self.started = false;
+            // self.start = self.stop;
+            self.stats.add(self.delta.as_micros() as f64)
+        } else {
+            panic!("Can't do this")
+        }
+    }
+    pub fn reset(&mut self) {
+        self.stats.reset();
+    }
+    pub fn stats(&self, stats: &mut Stats) {
+        *stats = self.stats;
+    }
+}

--- a/time_stats/src/main.rs
+++ b/time_stats/src/main.rs
@@ -1,0 +1,32 @@
+#![no_std]
+#![no_main]
+#![feature(type_alias_impl_trait)]
+
+use defmt::*;
+use {defmt_rtt as _, panic_probe as _};
+use embassy_executor::Spawner;
+use embassy_time::{Timer,Instant};
+
+use stats::Stats;
+use time_stats::TimeStats;
+
+fn show(s: Stats) {
+    println!("{} {}/{}/{} {}",
+             s.n(), s.min(), s.mean(), s.max(), s.std());
+}
+
+#[embassy_executor::main]
+async fn main(_spawner: Spawner) {
+    let _ = embassy_stm32::init(Default::default());
+    let s = Stats::new();
+    let mut ts = TimeStats::new();
+    // let mut t = Instant::now().as_millis();
+    for _i in 1..=100 {
+        // t += 1;
+        // Timer::at(Instant::from_millis(t)).await;
+        ts.loop_tick();
+    }
+    show(s);
+    Timer::after_millis(100).await;
+    println!("Done!");
+}


### PR DESCRIPTION
Fixed what I could fix from #3. It seems `Timer::after_ticks(0)` is slow in --debug builds.

There is now instrumentation on the display and adc threads to know when they are overruning.

A (large) `Channel` was used in place of `Signal` to fix dropped ADC samples in `process_hr` task.